### PR TITLE
Remove '--pre' install flag on PyPI CI test.

### DIFF
--- a/.ci/install_script.sh
+++ b/.ci/install_script.sh
@@ -11,7 +11,7 @@ cd ${TRAVIS_BUILD_DIR}
 
 case "$INSTALL_TYPE" in
     test_pypi)
-        pip install --pre fsc.export[test]
+        pip install fsc.export[test]
         ;;
     test_sdist)
         python setup.py sdist


### PR DESCRIPTION
Now that both 1.1.1 and 1.2.0 are released, the CI test should run without the ``--pre`` flag as well, and install the appropriate version in each case.